### PR TITLE
Fix/cleanup pricing UI

### DIFF
--- a/public/js/header.tpl.js
+++ b/public/js/header.tpl.js
@@ -43,11 +43,6 @@
                 <li
                   class="menu-item menu-item-type-post_type menu-item-object-page"
                 >
-                  <a href="/pricing.html">Pricing</a>
-                </li>
-                <li
-                  class="menu-item menu-item-type-post_type menu-item-object-page"
-                >
                   <a href="/events.html">Events</a>
                 </li>
                 <li

--- a/public/testimonials.html
+++ b/public/testimonials.html
@@ -23,12 +23,7 @@
       <main id="content" class="site-content" style="min-height: 1px;">
         <div class="container">
           <h2 class="entry-title">Testimonials</h2>
-          <script async src="/js/testimonials.tpl.js" end="1"></script>
-          <div class="testimonials-pricing">
-            <h4>Fixed Fees</h1>
-            <script async src="/js/pricing-grid.tpl.js"></script>
-          </div>
-          <script async src="/js/testimonials.tpl.js" start="1"></script>
+          <script async src="/js/testimonials.tpl.js"></script>
         </div>
         <!-- Calendly badge widget begin -->
         <link


### PR DESCRIPTION
Makes these changes to the cobalt page at Thomas' request:

> Edits:
> 
> 1) On Cobalt's testimonials page, can we please remove the entire "Fixed Fees" box, so that it's just the testimonials? Pricing is starting to confuse people so we'd rather just remove it entirely
> 
> 2) Can we remove the "Pricing" button on the header? We don't want to deactivate the page, we just don't want people to be able to visit it except for us.